### PR TITLE
Improve alloy solver robustness, performance, and no-solution diagnostics

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,7 @@
 name: Deploy to GitHub Pages
 
 on:
+  workflow_dispatch:
   push:
     branches: 'master'
 

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ Thumbs.db
 # Vite
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+/.idea/

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Calculator for calculating optimal combination of ores in TerraFirmaCraft originally created to try out Tailwind and Flolwbite
 
+Link to the tool: https://v4kodin.github.io/tfg-m-orecalc/
+
 ## Building and running from source
 #### Building steps
 1. [Download and install NodeJS 20 or higher](https://nodejs.org/en/download)

--- a/src/lib/interfaces.ts
+++ b/src/lib/interfaces.ts
@@ -47,7 +47,7 @@ export interface Result {
 	approximation: boolean;
 	timedout: boolean;
 	time: number;
-
+	error?: string;
 }
 
 export interface Preset {

--- a/src/lib/math.ts
+++ b/src/lib/math.ts
@@ -2,6 +2,52 @@ import type { Combination, Metal, Ore, OreInfo, Params, Result, Settings } from 
 
 export const defaultQuantity = 32;
 const normalizeId = (value: string) => value.trim().toLowerCase();
+const getOreName = (ore: Ore) => ore.name?.trim() || "<unnamed ore>";
+
+const fail = (error: string): Result => ({
+	combinations: [],
+	approximation: false,
+	timedout: false,
+	time: 0,
+	error
+});
+
+function validateInput(metals: Metal[], params: Params): string | undefined {
+	const { multipleOf, min, max } = params;
+
+	if (multipleOf <= 0)
+		return "Multiple of must be greater than 0";
+	if (min > max)
+		return "Min mB cannot be greater than Max mB";
+	if (metals.length === 0)
+		return "No metals configured";
+
+	const unique = new Set<string>();
+	let sumMin = 0;
+	let sumMax = 0;
+
+	for (const metal of metals) {
+		const key = normalizeId(metal.id);
+		if (!key)
+			return "Metal id cannot be empty";
+		if (unique.has(key))
+			return `Duplicate metal id: ${metal.id}`;
+		unique.add(key);
+
+		if (metal.percent.min < 0 || metal.percent.max > 100 || metal.percent.min > metal.percent.max)
+			return `Invalid percentage range for metal ${metal.id}`;
+
+		sumMin += metal.percent.min;
+		sumMax += metal.percent.max;
+	}
+
+	if (sumMin > 100)
+		return `Invalid configuration: sum of minimum percentages is ${sumMin}% (> 100%)`;
+	if (sumMax < 100)
+		return `Invalid configuration: sum of maximum percentages is ${sumMax}% (< 100%)`;
+
+	return undefined;
+}
 
 function* product<T>(...pools: T[][]): Iterable<T[]> {
     const head = pools[0];
@@ -22,11 +68,12 @@ export function generateAlloyCombinations(metals: Metal[], ores: Ore[], params: 
 	const start = Date.now();
 	let timedout = false;
 
-	if (metals.length === 0)
-		return { combinations: [], approximation: false, timedout: false, time: 0, error: "No metals configured" };
+	const inputError = validateInput(metals, params);
+	if (inputError)
+		return fail(inputError);
 
 	if (ores.length === 0)
-		return { combinations: [], approximation: false, timedout: false, time: 0, error: "No ores configured" };
+		return fail("No ores configured");
 
 	const metalById = metals.reduce((acc, metal) => {
 		acc[normalizeId(metal.id)] = metal;
@@ -35,16 +82,16 @@ export function generateAlloyCombinations(metals: Metal[], ores: Ore[], params: 
 
 	const unresolvedOres = ores
 		.filter(ore => !metalById[normalizeId(ore.id)])
-		.map(ore => ore.name || "<unnamed ore>");
+		.map(getOreName);
 
 	if (unresolvedOres.length > 0)
-		return {
-			combinations: [],
-			approximation: false,
-			timedout: false,
-			time: 0,
-			error: `Ores with unknown metal id: ${unresolvedOres.join(", ")}`
-		};
+		return fail(`Ores with unknown metal id: ${unresolvedOres.join(", ")}`);
+
+	const invalidWeightOres = ores.filter(ore => ore.weight <= 0).map(getOreName);
+	if (invalidWeightOres.length > 0)
+		return fail(`Ores with non-positive weight: ${invalidWeightOres.join(", ")}`);
+
+	const zeroLimitOres = ores.filter(ore => (ore.quantity ?? defaultQuantity) <= 0).map(getOreName);
 
 	// Sort ores first by metal percentage and then by weight
 	const sortedMetals = [...metals]
@@ -61,7 +108,7 @@ export function generateAlloyCombinations(metals: Metal[], ores: Ore[], params: 
 		.filter(ore => ore.quantity > 0);
 
 	if (sortedOres.length === 0)
-		return { combinations: [], approximation: false, timedout: false, time: 0, error: "No ores with quantity > 0" };
+		return fail(`No ores with quantity > 0. Ores with zero limit: ${zeroLimitOres.join(", ")}`);
 
 	const oreQuantities = sortedOres
 		.map(ore => Array.from({ length: (ore.quantity ?? defaultQuantity) + 1 }, (_, i) => i))
@@ -152,6 +199,9 @@ export function generateAlloyCombinations(metals: Metal[], ores: Ore[], params: 
 			error = "No combinations match multiple/tolerance constraints";
 		else if (checked === 0)
 			error = "No candidate combinations generated from current ore quantity limits";
+
+		if (error && zeroLimitOres.length > 0)
+			error = `${error}. Ores with zero limit: ${zeroLimitOres.join(", ")}`;
 	}
 
 	return {

--- a/src/lib/math.ts
+++ b/src/lib/math.ts
@@ -1,6 +1,5 @@
 import type { Combination, Metal, Ore, OreInfo, Params, Result, Settings } from "./interfaces"
 
-export const defaultQuantity = 32;
 const normalizeId = (value: string) => value.trim().toLowerCase();
 const getOreName = (ore: Ore) => ore.name?.trim() || "<unnamed ore>";
 const epsilon = 1e-9;
@@ -169,7 +168,7 @@ export function generateAlloyCombinations(metals: Metal[], ores: Ore[], params: 
 	if (invalidWeightOres.length > 0)
 		return fail(`Ores with non-positive weight: ${invalidWeightOres.join(", ")}`);
 
-	const zeroLimitOres = ores.filter(ore => (ore.quantity ?? defaultQuantity) <= 0).map(getOreName);
+	const zeroLimitOres = ores.filter(ore => typeof ore.quantity === "number" && ore.quantity <= 0).map(getOreName);
 	const cappedByMaxOres: string[] = [];
 
 	// Sort ores first by metal percentage and then by weight
@@ -184,14 +183,14 @@ export function generateAlloyCombinations(metals: Metal[], ores: Ore[], params: 
 			b.weight - a.weight
 		)
 		.map(ore => {
-			const quantity = ore.quantity ?? defaultQuantity;
+			const quantity = ore.quantity ?? infinity;
 			const maxQtyByWeight = Math.floor(max / ore.weight);
 			const effectiveMaxQty = Math.min(quantity, Math.max(0, maxQtyByWeight));
 			if (quantity > 0 && effectiveMaxQty === 0)
 				cappedByMaxOres.push(getOreName(ore));
 			return { ...ore, quantity, effectiveMaxQty, metalIndex: metalIndexById[normalizeId(ore.id)] };
 		})
-		.filter(ore => ore.quantity > 0);
+		.filter(ore => ore.effectiveMaxQty > 0);
 
 	if (sortedOres.length === 0)
 		return fail(`No ores with quantity > 0. Ores with zero limit: ${zeroLimitOres.join(", ")}`);

--- a/src/lib/math.ts
+++ b/src/lib/math.ts
@@ -92,6 +92,7 @@ export function generateAlloyCombinations(metals: Metal[], ores: Ore[], params: 
 		return fail(`Ores with non-positive weight: ${invalidWeightOres.join(", ")}`);
 
 	const zeroLimitOres = ores.filter(ore => (ore.quantity ?? defaultQuantity) <= 0).map(getOreName);
+	const cappedByMaxOres: string[] = [];
 
 	// Sort ores first by metal percentage and then by weight
 	const sortedMetals = [...metals]
@@ -104,14 +105,21 @@ export function generateAlloyCombinations(metals: Metal[], ores: Ore[], params: 
 			sortedMetals[normalizeId(a.id)] - sortedMetals[normalizeId(b.id)] ||
 			b.weight - a.weight
 		)
-		.map(ore => ({ ...ore, quantity: ore.quantity ?? defaultQuantity }))
+		.map(ore => {
+			const quantity = ore.quantity ?? defaultQuantity;
+			const maxQtyByWeight = Math.floor(max / ore.weight);
+			const effectiveMaxQty = Math.min(quantity, Math.max(0, maxQtyByWeight));
+			if (quantity > 0 && effectiveMaxQty === 0)
+				cappedByMaxOres.push(getOreName(ore));
+			return { ...ore, quantity, effectiveMaxQty };
+		})
 		.filter(ore => ore.quantity > 0);
 
 	if (sortedOres.length === 0)
 		return fail(`No ores with quantity > 0. Ores with zero limit: ${zeroLimitOres.join(", ")}`);
 
 	const oreQuantities = sortedOres
-		.map(ore => Array.from({ length: (ore.quantity ?? defaultQuantity) + 1 }, (_, i) => i))
+		.map(ore => Array.from({ length: ore.effectiveMaxQty + 1 }, (_, i) => i))
 
 	let rejectedByWeight = 0;
 	let rejectedByPercent = 0;
@@ -202,6 +210,8 @@ export function generateAlloyCombinations(metals: Metal[], ores: Ore[], params: 
 
 		if (error && zeroLimitOres.length > 0)
 			error = `${error}. Ores with zero limit: ${zeroLimitOres.join(", ")}`;
+		if (error && cappedByMaxOres.length > 0)
+			error = `${error}. Ignored by Max mB limit: ${cappedByMaxOres.join(", ")}`;
 	}
 
 	return {

--- a/src/lib/math.ts
+++ b/src/lib/math.ts
@@ -4,6 +4,7 @@ export const defaultQuantity = 32;
 const normalizeId = (value: string) => value.trim().toLowerCase();
 const getOreName = (ore: Ore) => ore.name?.trim() || "<unnamed ore>";
 const epsilon = 1e-9;
+const infinity = Number.POSITIVE_INFINITY;
 
 const fail = (error: string): Result => ({
 	combinations: [],
@@ -12,6 +13,87 @@ const fail = (error: string): Result => ({
 	time: 0,
 	error
 });
+
+const distanceToNearestMultiple = (value: number, multipleOf: number): number => {
+	if (multipleOf <= 0)
+		return infinity;
+	const remainder = value % multipleOf;
+	if (remainder === 0)
+		return 0;
+	return Math.min(remainder, multipleOf - remainder);
+};
+
+const buildNoCombinationError = (input: {
+	rejectedByWeight: number;
+	rejectedByPercent: number;
+	rejectedByMultiple: number;
+	zeroLimitOres: string[];
+	cappedByMaxOres: string[];
+	metals: Metal[];
+	availableMetalWeight: number[];
+	minWeight: number;
+	multipleOf: number;
+	tolerance: number;
+	multipleCandidateCount: number;
+	multipleAllBelow: boolean;
+	minMultipleDistance: number;
+}): string => {
+	const {
+		rejectedByWeight,
+		rejectedByPercent,
+		rejectedByMultiple,
+		zeroLimitOres,
+		cappedByMaxOres,
+		metals,
+		availableMetalWeight,
+		minWeight,
+		multipleOf,
+		tolerance,
+		multipleCandidateCount,
+		multipleAllBelow,
+		minMultipleDistance
+	} = input;
+
+	let headline = "No combinations found";
+	if (rejectedByPercent >= rejectedByWeight && rejectedByPercent >= rejectedByMultiple && rejectedByPercent > 0)
+		headline = "No combinations match the configured metal percentage ranges";
+	else if (rejectedByWeight >= rejectedByPercent && rejectedByWeight >= rejectedByMultiple && rejectedByWeight > 0)
+		headline = "No combinations fit within Min/Max weight limits";
+	else if (rejectedByMultiple > 0)
+		headline = "No combinations match multiple/tolerance constraints";
+
+	const details: string[] = [];
+	if (zeroLimitOres.length > 0)
+		details.push(`ores with zero limit: ${zeroLimitOres.join(", ")}`);
+	if (cappedByMaxOres.length > 0)
+		details.push(`ignored by Max mB limit: ${cappedByMaxOres.join(", ")}`);
+
+	const shortage = metals
+		.map((metal, index) => {
+			if (metal.percent.min <= 0)
+				return "";
+			const requiredAtMin = (metal.percent.min / 100) * minWeight;
+			const available = availableMetalWeight[index];
+			if (available + epsilon < requiredAtMin)
+				return `${metal.id} needs >= ${requiredAtMin.toFixed(2)} mB at Min, available ${available.toFixed(2)} mB`;
+			return "";
+		})
+		.filter(Boolean);
+
+	if (shortage.length > 0)
+		details.push(`insufficient ore for required percentages: ${shortage.join("; ")}`);
+
+	if (multipleCandidateCount > 0) {
+		if (multipleAllBelow)
+			details.push(`all percentage-valid candidates are below Multiple of ${multipleOf} mB`);
+		else if (minMultipleDistance < infinity)
+			details.push(`closest candidate misses multiple by ${minMultipleDistance} mB (tolerance ${tolerance} mB)`);
+		if (tolerance <= 0)
+			details.push("approximation is disabled (tolerance = 0)");
+	}
+
+	return details.length > 0 ? `${headline}. Causes: ${details.join(". ")}` : headline;
+};
 
 function validateInput(metals: Metal[], params: Params): string | undefined {
 	const { multipleOf, min, max } = params;
@@ -118,6 +200,9 @@ export function generateAlloyCombinations(metals: Metal[], ores: Ore[], params: 
 	let rejectedByPercent = 0;
 	let rejectedByMultiple = 0;
 	let checked = 0;
+	let multipleCandidateCount = 0;
+	let multipleAllBelow = true;
+	let minMultipleDistance = infinity;
 
 	const oreCount = sortedOres.length;
 	const metalCount = metals.length;
@@ -132,6 +217,7 @@ export function generateAlloyCombinations(metals: Metal[], ores: Ore[], params: 
 		suffixMetalMax[i] = [...suffixMetalMax[i + 1]];
 		suffixMetalMax[i][ore.metalIndex] += ore.weight * ore.effectiveMaxQty;
 	}
+	const availableMetalWeight = [...suffixMetalMax[0]];
 
 	const pushCombination = (finalWeight: number, valid: boolean) => {
 		const details: OreInfo[] = [];
@@ -223,9 +309,13 @@ export function generateAlloyCombinations(metals: Metal[], ores: Ore[], params: 
 			}
 
 			const valid = currentWeight % multipleOf === 0;
-			const approximation = Math.abs(currentWeight - multipleOf) <= tolerance;
+			const multipleDistance = distanceToNearestMultiple(currentWeight, multipleOf);
+			const approximation = multipleDistance <= tolerance;
 			if (!valid && !approximation) {
 				rejectedByMultiple++;
+				multipleCandidateCount++;
+				multipleAllBelow = multipleAllBelow && currentWeight < multipleOf;
+				minMultipleDistance = Math.min(minMultipleDistance, multipleDistance);
 				return;
 			}
 
@@ -267,19 +357,24 @@ export function generateAlloyCombinations(metals: Metal[], ores: Ore[], params: 
 	if (combinations.length === 0) {
 		if (timedout)
 			error = "Calculation timed out before finding any matching combinations";
-		else if (rejectedByPercent > 0 && rejectedByPercent >= rejectedByWeight && rejectedByPercent >= rejectedByMultiple)
-			error = "No combinations match the configured metal percentage ranges";
-		else if (rejectedByWeight > 0 && rejectedByWeight >= rejectedByPercent && rejectedByWeight >= rejectedByMultiple)
-			error = "No combinations fit within Min/Max weight limits";
-		else if (rejectedByMultiple > 0)
-			error = "No combinations match multiple/tolerance constraints";
-		else if (checked === 0)
+		else if (checked === 0 && rejectedByWeight === 0 && rejectedByPercent === 0 && rejectedByMultiple === 0)
 			error = "No candidate combinations generated from current ore quantity limits";
-
-		if (error && zeroLimitOres.length > 0)
-			error = `${error}. Ores with zero limit: ${zeroLimitOres.join(", ")}`;
-		if (error && cappedByMaxOres.length > 0)
-			error = `${error}. Ignored by Max mB limit: ${cappedByMaxOres.join(", ")}`;
+		else
+			error = buildNoCombinationError({
+				rejectedByWeight,
+				rejectedByPercent,
+				rejectedByMultiple,
+				zeroLimitOres,
+				cappedByMaxOres,
+				metals,
+				availableMetalWeight,
+				minWeight: min,
+				multipleOf,
+				tolerance,
+				multipleCandidateCount,
+				multipleAllBelow,
+				minMultipleDistance
+			});
 	}
 
 	return {

--- a/src/lib/math.ts
+++ b/src/lib/math.ts
@@ -3,6 +3,7 @@ import type { Combination, Metal, Ore, OreInfo, Params, Result, Settings } from 
 export const defaultQuantity = 32;
 const normalizeId = (value: string) => value.trim().toLowerCase();
 const getOreName = (ore: Ore) => ore.name?.trim() || "<unnamed ore>";
+const epsilon = 1e-9;
 
 const fail = (error: string): Result => ({
 	combinations: [],
@@ -49,15 +50,6 @@ function validateInput(metals: Metal[], params: Params): string | undefined {
 	return undefined;
 }
 
-function* product<T>(...pools: T[][]): Iterable<T[]> {
-    const head = pools[0];
-    const tail = pools.slice(1);
-    const remainder = tail.length > 0 ? product(...tail) : [[]];
-    for (let r of remainder)
-		for (let h of head)
-			yield [h, ...r];
-}
-
 export function generateAlloyCombinations(metals: Metal[], ores: Ore[], params: Params, settings: Settings): Result {
 	const { multipleOf, tolerance, min, max } = params;
 	const { count, timeout } = settings;
@@ -79,6 +71,10 @@ export function generateAlloyCombinations(metals: Metal[], ores: Ore[], params: 
 		acc[normalizeId(metal.id)] = metal;
 		return acc;
 	}, {} as Record<string, Metal>);
+	const metalIndexById = metals.reduce((acc, metal, index) => {
+		acc[normalizeId(metal.id)] = index;
+		return acc;
+	}, {} as Record<string, number>);
 
 	const unresolvedOres = ores
 		.filter(ore => !metalById[normalizeId(ore.id)])
@@ -111,73 +107,44 @@ export function generateAlloyCombinations(metals: Metal[], ores: Ore[], params: 
 			const effectiveMaxQty = Math.min(quantity, Math.max(0, maxQtyByWeight));
 			if (quantity > 0 && effectiveMaxQty === 0)
 				cappedByMaxOres.push(getOreName(ore));
-			return { ...ore, quantity, effectiveMaxQty };
+			return { ...ore, quantity, effectiveMaxQty, metalIndex: metalIndexById[normalizeId(ore.id)] };
 		})
 		.filter(ore => ore.quantity > 0);
 
 	if (sortedOres.length === 0)
 		return fail(`No ores with quantity > 0. Ores with zero limit: ${zeroLimitOres.join(", ")}`);
 
-	const oreQuantities = sortedOres
-		.map(ore => Array.from({ length: ore.effectiveMaxQty + 1 }, (_, i) => i))
-
 	let rejectedByWeight = 0;
 	let rejectedByPercent = 0;
 	let rejectedByMultiple = 0;
 	let checked = 0;
 
-	for (const quantities of product(...oreQuantities)) {
-		if ((timedout = Date.now() - start > timeout * 1000) || validCombinations.length >= count)
-			break;
+	const oreCount = sortedOres.length;
+	const metalCount = metals.length;
+	const quantities = new Array<number>(oreCount).fill(0);
+	const metalWeights = new Array<number>(metalCount).fill(0);
 
-		let finalWeight = 0;
-		const totalQuantity = quantities.reduce((acc, val) => acc + val, 0);
+	const suffixMaxWeight = new Array<number>(oreCount + 1).fill(0);
+	const suffixMetalMax = Array.from({ length: oreCount + 1 }, () => new Array<number>(metalCount).fill(0));
+	for (let i = oreCount - 1; i >= 0; i--) {
+		const ore = sortedOres[i];
+		suffixMaxWeight[i] = suffixMaxWeight[i + 1] + ore.weight * ore.effectiveMaxQty;
+		suffixMetalMax[i] = [...suffixMetalMax[i + 1]];
+		suffixMetalMax[i][ore.metalIndex] += ore.weight * ore.effectiveMaxQty;
+	}
+
+	const pushCombination = (finalWeight: number, valid: boolean) => {
 		const details: OreInfo[] = [];
-
-		if (totalQuantity == 0)
-			continue;
-
-		sortedOres.forEach((ore, i) => {
-			if (quantities[i] > 0) {
-				const weight = quantities[i] * ore.weight;
-				finalWeight += weight;
-				details.push({ id: ore.id, name: ore.name, weight, quantity: quantities[i] });
-			}
-		});
-
-		if (finalWeight < min || finalWeight > max)
-		{
-			rejectedByWeight++;
-			continue;
+		for (let i = 0; i < oreCount; i++) {
+			if (quantities[i] <= 0)
+				continue;
+			details.push({
+				id: sortedOres[i].id,
+				name: sortedOres[i].name,
+				weight: quantities[i] * sortedOres[i].weight,
+				quantity: quantities[i]
+			});
 		}
-
-		let percentagesMet = true;
-		metals.forEach((metal) => {
-			const metalWeight = details
-				.filter(w => w.id === metal.id)
-				.reduce((acc, val) => acc + val.weight, 0);
-			const percentage = (metalWeight / finalWeight) * 100;
-
-			if (!(metal.percent.min <= percentage && percentage <= metal.percent.max))
-				percentagesMet = false;
-		});
-
-		if (!percentagesMet)
-		{
-			rejectedByPercent++;
-			continue;
-		}
-
-		const valid = finalWeight % multipleOf === 0 && finalWeight > 0;
-		const approximation = Math.abs(finalWeight - multipleOf) <= tolerance && finalWeight > 0;
-		
-		if (!valid && !approximation)
-		{
-			rejectedByMultiple++;
-			continue;
-		}
-
-		checked++;
 
 		(valid ? validCombinations : approximationCombinations).push({
 			details,
@@ -188,7 +155,108 @@ export function generateAlloyCombinations(metals: Metal[], ores: Ore[], params: 
 				multipleOf
 			}
 		});
-	}
+	};
+
+	const dfs = (index: number, currentWeight: number) => {
+		if (timedout || validCombinations.length >= count)
+			return;
+		if (Date.now() - start > timeout * 1000) {
+			timedout = true;
+			return;
+		}
+
+		if (currentWeight > max) {
+			rejectedByWeight++;
+			return;
+		}
+
+		const maxReachableWeight = currentWeight + suffixMaxWeight[index];
+		if (maxReachableWeight < min) {
+			rejectedByWeight++;
+			return;
+		}
+
+		const possibleWeightMin = Math.max(min, currentWeight);
+		const possibleWeightMax = Math.min(max, maxReachableWeight);
+
+		for (let metalIndex = 0; metalIndex < metalCount; metalIndex++) {
+			const currentMetalWeight = metalWeights[metalIndex];
+			const maxMetalWeight = currentMetalWeight + suffixMetalMax[index][metalIndex];
+			const minPercent = metals[metalIndex].percent.min;
+			const maxPercent = metals[metalIndex].percent.max;
+
+			if (minPercent > 0) {
+				const maxWeightForMinConstraint = (maxMetalWeight * 100) / minPercent;
+				if (possibleWeightMin - epsilon > maxWeightForMinConstraint) {
+					rejectedByPercent++;
+					return;
+				}
+			}
+
+			if (maxPercent <= 0) {
+				if (currentMetalWeight > 0) {
+					rejectedByPercent++;
+					return;
+				}
+			} else {
+				const minWeightForMaxConstraint = (currentMetalWeight * 100) / maxPercent;
+				if (possibleWeightMax + epsilon < minWeightForMaxConstraint) {
+					rejectedByPercent++;
+					return;
+				}
+			}
+		}
+
+		if (index === oreCount) {
+			if (currentWeight <= 0 || currentWeight < min || currentWeight > max) {
+				rejectedByWeight++;
+				return;
+			}
+
+			for (let metalIndex = 0; metalIndex < metalCount; metalIndex++) {
+				const percentage = (metalWeights[metalIndex] / currentWeight) * 100;
+				const range = metals[metalIndex].percent;
+				if (percentage + epsilon < range.min || percentage - epsilon > range.max) {
+					rejectedByPercent++;
+					return;
+				}
+			}
+
+			const valid = currentWeight % multipleOf === 0;
+			const approximation = Math.abs(currentWeight - multipleOf) <= tolerance;
+			if (!valid && !approximation) {
+				rejectedByMultiple++;
+				return;
+			}
+
+			checked++;
+			pushCombination(currentWeight, valid);
+			return;
+		}
+
+		const ore = sortedOres[index];
+		for (let qty = ore.effectiveMaxQty; qty >= 0; qty--) {
+			const addedWeight = qty * ore.weight;
+			const nextWeight = currentWeight + addedWeight;
+			if (nextWeight > max)
+				continue;
+
+			quantities[index] = qty;
+			if (qty > 0)
+				metalWeights[ore.metalIndex] += addedWeight;
+
+			dfs(index + 1, nextWeight);
+
+			if (qty > 0)
+				metalWeights[ore.metalIndex] -= addedWeight;
+			quantities[index] = 0;
+
+			if (timedout || validCombinations.length >= count)
+				break;
+		}
+	};
+
+	dfs(0, 0);
 
 	const hasValid = validCombinations.length > 0;
 	const combinations = hasValid

--- a/src/lib/math.ts
+++ b/src/lib/math.ts
@@ -1,6 +1,7 @@
 import type { Combination, Metal, Ore, OreInfo, Params, Result, Settings } from "./interfaces"
 
 export const defaultQuantity = 32;
+const normalizeId = (value: string) => value.trim().toLowerCase();
 
 function* product<T>(...pools: T[][]): Iterable<T[]> {
     const head = pools[0];
@@ -21,21 +22,54 @@ export function generateAlloyCombinations(metals: Metal[], ores: Ore[], params: 
 	const start = Date.now();
 	let timedout = false;
 
-	// Sort ores first by metal percentage and then by weight
-	const sortedMetals = metals
-		.sort((a, b) => b.percent.min - a.percent.min)
-		.reduce((acc, v, k) => ({ ...acc, [v.id]: k }), {} as Record<string, number>);
+	if (metals.length === 0)
+		return { combinations: [], approximation: false, timedout: false, time: 0, error: "No metals configured" };
 
-	const sortedOres = ores
+	if (ores.length === 0)
+		return { combinations: [], approximation: false, timedout: false, time: 0, error: "No ores configured" };
+
+	const metalById = metals.reduce((acc, metal) => {
+		acc[normalizeId(metal.id)] = metal;
+		return acc;
+	}, {} as Record<string, Metal>);
+
+	const unresolvedOres = ores
+		.filter(ore => !metalById[normalizeId(ore.id)])
+		.map(ore => ore.name || "<unnamed ore>");
+
+	if (unresolvedOres.length > 0)
+		return {
+			combinations: [],
+			approximation: false,
+			timedout: false,
+			time: 0,
+			error: `Ores with unknown metal id: ${unresolvedOres.join(", ")}`
+		};
+
+	// Sort ores first by metal percentage and then by weight
+	const sortedMetals = [...metals]
+		.sort((a, b) => b.percent.min - a.percent.min)
+		.reduce((acc, v, k) => ({ ...acc, [normalizeId(v.id)]: k }), {} as Record<string, number>);
+
+	const sortedOres = [...ores]
+		.map(ore => ({ ...ore, id: metalById[normalizeId(ore.id)]?.id ?? ore.id }))
 		.sort((a , b) => 
-			sortedMetals[a.id] - sortedMetals[b.id] ||
+			sortedMetals[normalizeId(a.id)] - sortedMetals[normalizeId(b.id)] ||
 			b.weight - a.weight
 		)
 		.map(ore => ({ ...ore, quantity: ore.quantity ?? defaultQuantity }))
 		.filter(ore => ore.quantity > 0);
 
+	if (sortedOres.length === 0)
+		return { combinations: [], approximation: false, timedout: false, time: 0, error: "No ores with quantity > 0" };
+
 	const oreQuantities = sortedOres
 		.map(ore => Array.from({ length: (ore.quantity ?? defaultQuantity) + 1 }, (_, i) => i))
+
+	let rejectedByWeight = 0;
+	let rejectedByPercent = 0;
+	let rejectedByMultiple = 0;
+	let checked = 0;
 
 	for (const quantities of product(...oreQuantities)) {
 		if ((timedout = Date.now() - start > timeout * 1000) || validCombinations.length >= count)
@@ -57,7 +91,10 @@ export function generateAlloyCombinations(metals: Metal[], ores: Ore[], params: 
 		});
 
 		if (finalWeight < min || finalWeight > max)
+		{
+			rejectedByWeight++;
 			continue;
+		}
 
 		let percentagesMet = true;
 		metals.forEach((metal) => {
@@ -71,13 +108,21 @@ export function generateAlloyCombinations(metals: Metal[], ores: Ore[], params: 
 		});
 
 		if (!percentagesMet)
+		{
+			rejectedByPercent++;
 			continue;
+		}
 
 		const valid = finalWeight % multipleOf === 0 && finalWeight > 0;
 		const approximation = Math.abs(finalWeight - multipleOf) <= tolerance && finalWeight > 0;
 		
 		if (!valid && !approximation)
+		{
+			rejectedByMultiple++;
 			continue;
+		}
+
+		checked++;
 
 		(valid ? validCombinations : approximationCombinations).push({
 			details,
@@ -90,20 +135,30 @@ export function generateAlloyCombinations(metals: Metal[], ores: Ore[], params: 
 		});
 	}
 
+	const hasValid = validCombinations.length > 0;
+	const combinations = hasValid
+		? validCombinations.sort((a, b) => a.finalWeight.total - b.finalWeight.total)
+		: approximationCombinations.sort((a, b) => a.finalWeight.total - b.finalWeight.total).slice(0, count);
+
+	let error: string | undefined;
+	if (combinations.length === 0) {
+		if (timedout)
+			error = "Calculation timed out before finding any matching combinations";
+		else if (rejectedByPercent > 0 && rejectedByPercent >= rejectedByWeight && rejectedByPercent >= rejectedByMultiple)
+			error = "No combinations match the configured metal percentage ranges";
+		else if (rejectedByWeight > 0 && rejectedByWeight >= rejectedByPercent && rejectedByWeight >= rejectedByMultiple)
+			error = "No combinations fit within Min/Max weight limits";
+		else if (rejectedByMultiple > 0)
+			error = "No combinations match multiple/tolerance constraints";
+		else if (checked === 0)
+			error = "No candidate combinations generated from current ore quantity limits";
+	}
+
 	return {
-		...validCombinations.length > 0
-		? {
-			approximation: false,
-			combinations: validCombinations
-				.sort((a, b) => a.finalWeight.total - b.finalWeight.total)
-		}
-		: {
-			approximation: true,
-			combinations: approximationCombinations
-				.sort((a, b) => a.finalWeight.total - b.finalWeight.total)
-				.slice(0, count)
-		},
+		approximation: !hasValid,
+		combinations,
 		time: (Date.now() - start) / 1000,
-		timedout
+		timedout,
+		error
 	};
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -185,7 +185,7 @@
 			{:else}
 				<Alert color="red">
 					<InfoCircleSolid slot="icon" class="w-5 h-5" />
-					<span class="font-medium">No combinations (including approximate) found</span>
+					<span class="font-medium">{result.error ?? "No combinations (including approximate) found"}</span>
 				</Alert>
 			{/if}
 		{/if}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { Metal, Ore, Params, Result } from "$lib/interfaces";
 	import { preset, settings as settingsStore } from "$lib/stores";
-	import { generateAlloyCombinations, defaultQuantity } from "$lib/math";
+	import { generateAlloyCombinations } from "$lib/math";
 
 	import { Card, Button, Input, Select, Range, Label, Alert, Table, TableBody, TableBodyCell, TableBodyRow, TableHead, TableHeadCell, Toggle } from "flowbite-svelte";
 	import { TrashBinSolid, InfoCircleSolid, CloseCircleSolid } from "flowbite-svelte-icons";
@@ -114,7 +114,7 @@
 						<Label class="w-[60px] text-left">mB</Label>
 					</div>
 					<div class="flex flex-row gap-2 items-center">
-						<Input type="number" bind:value={ore.quantity} placeholder="Limit (optional, default: {defaultQuantity})"/>
+						<Input type="number" bind:value={ore.quantity} placeholder="Limit (optional, default: unlimited)"/>
 						{#if typeof ore.quantity === "number"}
 							<Button
 								color="alternative"


### PR DESCRIPTION
### **_This PR improves the alloy combination solver in three areas: input safety, search performance, and user-facing diagnostics when no solution is found._**

### Summary
- Added stricter upfront validation for metals/ores/params with explicit error messages.
- Replaced full Cartesian enumeration with a branch-and-bound DFS search.
- Reduced search space by capping ore quantities using Max mB.
- Added detailed no-solution diagnostics for percentage and Multiple Of constraints.
- Exposed solver errors in the Result interface and rendered them in UI alerts.
- Added /.idea/ to .gitignore.

### Detailed changes

1. **Error propagation to UI**

    - Result now includes optional error?: string.
    - Calculation errors are returned from solver instead of silently failing.
    - Result panel now displays result.error in the red alert fallback.

2. **Upfront configuration validation**

    - Added early checks before search starts:
    - Multiple Of > 0
    - Min mB <= Max mB
    - non-empty metals list
    - non-empty, unique metal IDs
    - valid percent ranges (0..100, min <= max)
    - global percent feasibility (sum(min) <= 100, sum(max) >= 100)
    - non-empty ores list
    - ores mapped to known metal IDs
    - ore weight must be positive
    - Returns actionable, user-readable error text for each invalid case.

3. **Search-space reduction by max weight**

    - Introduced effectiveMaxQty = min(userQty, floor(maxWeight / oreWeight)).
    - Prevents generating impossible combinations that can never fit Max mB.
    - Tracks ores excluded by this cap for later diagnostics.

4. **Solver algorithm rewrite**

    - Replaced full product-style enumeration with DFS + branch-and-bound pruning.
    - Added suffix precomputations:
    - max reachable total weight from current index
    - max reachable per-metal weights from current index
    - Added early pruning when:
    - remaining weight cannot reach Min mB
    - per-metal min/max percentage constraints are impossible to satisfy
    - Preserved existing behavior for timeout, result limit, exact vs approximate matches, and sorting by final weight.

5. **Better no-solution diagnostics**

    - Added a diagnostic builder for zero-result runs that reports likely causes:
    - ores with zero quantity limit
    - ores effectively excluded by Max mB
    - metal shortages against minimum percentage requirements at Min mB
    - nearest distance to valid Multiple Of
    - tolerance impact (tolerance = 0 case)
    - dedicated case when percentage-valid candidates are all below Multiple Of
    - Chooses the headline cause based on dominant rejection category (weight / percent / multiple).

6. **Repo hygiene**

    - Added /.idea/ to .gitignore.

### Impact

- Faster solving on larger inputs due to pruning and tighter quantity bounds.
- More predictable failures through strict validation.
- Much clearer user guidance when no combinations are found.